### PR TITLE
Compression support

### DIFF
--- a/lib/large_object_store.rb
+++ b/lib/large_object_store.rb
@@ -8,7 +8,7 @@ module LargeObjectStore
   CACHE_VERSION = 2
   MAX_OBJECT_SIZE = 1024**2
   ITEM_HEADER_SIZE = 100
-  DEFAULT_COMPRESS_LIMIT = 16384
+  DEFAULT_COMPRESS_LIMIT = 16*1024
 
   def self.wrap(store)
     RailsWrapper.new(store)

--- a/spec/large_object_store_spec.rb
+++ b/spec/large_object_store_spec.rb
@@ -37,13 +37,13 @@ end
 
 RSpec::Matchers.define :be_compressed do
   match do |actual|
-    actual[LargeObjectStore::UUID_SIZE] == 'z' || actual[0] == 'z'
+    actual[LargeObjectStore::UUID_SIZE] == LargeObjectStore::COMPRESSED || actual[0] == LargeObjectStore::COMPRESSED
   end
 end
 
 RSpec::Matchers.define :be_uncompressed do
   match do |actual|
-    actual[LargeObjectStore::UUID_SIZE] == '0' || actual[0] == '0'
+    actual[LargeObjectStore::UUID_SIZE] == LargeObjectStore::NORMAL || actual[0] == LargeObjectStore::NORMAL
   end
 end
 

--- a/spec/large_object_store_spec.rb
+++ b/spec/large_object_store_spec.rb
@@ -35,6 +35,7 @@ class TestCache
   end
 end
 
+# compression indicator is in first position for single page values and after the uuid for multi page values
 RSpec::Matchers.define :be_compressed do
   match do |actual|
     actual[LargeObjectStore::UUID_SIZE] == LargeObjectStore::COMPRESSED || actual[0] == LargeObjectStore::COMPRESSED


### PR DESCRIPTION
Change the implementation to use a class called `CompressedEntry` to represent compressed data, instead of checking for zlib magic numbers