### PR TITLE
Fix slice size when keys are long

### DIFF
--- a/lib/large_object_store.rb
+++ b/lib/large_object_store.rb
@@ -23,13 +23,13 @@ module LargeObjectStore
 
       # calculate slice size; note that key length is a factor because
       # the key is stored on the same slab page as the value
-      slice_size = MAX_OBJECT_SIZE - ITEM_HEADER_SIZE - key.length
+      slice_size = MAX_OBJECT_SIZE - ITEM_HEADER_SIZE - key.bytesize
 
       # store number of pages
       pages = (value.size / slice_size.to_f).ceil
 
       if pages == 1
-        return false unless @store.write("#{key}_0", value, options.merge(raw: true))
+        @store.write("#{key}_0", value, options.merge(raw: true))
       else
         # store object
         page = 1
@@ -41,9 +41,8 @@ module LargeObjectStore
           page += 1
         end
 
-        return false unless @store.write("#{key}_0", pages, options)
+        @store.write("#{key}_0", pages, options)
       end
-      true
     end
 
     def read(key)

--- a/lib/large_object_store.rb
+++ b/lib/large_object_store.rb
@@ -29,7 +29,7 @@ module LargeObjectStore
       pages = (value.size / slice_size.to_f).ceil
 
       if pages == 1
-        @store.write("#{key}_0", value, options.merge(raw: true))
+        @store.write("#{key}_0", value, options)
       else
         # store object
         page = 1

--- a/lib/large_object_store.rb
+++ b/lib/large_object_store.rb
@@ -29,19 +29,19 @@ module LargeObjectStore
       pages = (value.size / slice_size.to_f).ceil
 
       if pages == 1
-        @store.write("#{key}_0", value, options.merge(raw: true))
+        return false unless @store.write("#{key}_0", value, options.merge(raw: true))
       else
-        @store.write("#{key}_0", pages, options)
-
         # store object
         page = 1
         loop do
           slice = value.slice!(0, slice_size)
           break if slice.size == 0
 
-          @store.write("#{key}_#{page}", slice, options.merge(raw: true))
+          return false unless @store.write("#{key}_#{page}", slice, options.merge(raw: true))
           page += 1
         end
+
+        return false unless @store.write("#{key}_0", pages, options)
       end
       true
     end

--- a/spec/large_object_store_spec.rb
+++ b/spec/large_object_store_spec.rb
@@ -53,7 +53,7 @@ describe LargeObjectStore do
   end
 
   it "passes options when caching small" do
-    store.store.should_receive(:write).with(anything, anything, :expires_in => 111, :raw => true).and_return(true)
+    store.store.should_receive(:write).with(anything, anything, :expires_in => 111).and_return(true)
     store.write("a", "a", :expires_in => 111)
   end
 


### PR DESCRIPTION
large_object_store currently uses a fixed slice size of 1024**1024-100 (1048476 bytes)

However, sometimes this limit leads to failed writes where the object slices do not fit on a memcached page.

This is because the *key* used for an item actually decreases the amount of memory available to the value.

From the memcached source code - I believe the memory layout of an item in a memcached slab includes this header, which includes the entire key.

```
/**                                                                                                                                                                        
 * Generates the variable-sized part of the header for an object.                                                                                                          
 *                                                                                                                                                                         
 * key     - The key                                                                                                                                                       
 * nkey    - The length of the key                                                                                                                                         
 * flags   - key flags                                                                                                                                                     
 * nbytes  - Number of bytes to hold value and addition CRLF terminator                                                                                                    
 * suffix  - Buffer for the "VALUE" line suffix (flags, size).                                                                                                             
 * nsuffix - The length of the suffix is stored here.                                                                                                                      
 *                                                                                                                                                                         
 * Returns the total size of the header.                                                                                                                                   
 */
```

Some experimentation which basically confirms this:

```
# Here we show that the item header needs 85 bytes when key length is 1.
> Rails.cache.write("X","X"*(1048576-84))
=> false
> Rails.cache.write("X","X"*(1048576-85))
=> true

# Now notice when key length goes to 2, 1048576-85 bytes no longer works.
> Rails.cache.write("XY","X"*(1048576-85))
=> false
# But it DOES work when you take one more byte off the value.
> Rails.cache.write("XY","X"*(1048576-86))
=> true

# And the pattern continues with a 3 byte key.
> Rails.cache.write("XYZ","X"*(1048576-86))
=> false
> Rails.cache.write("XYZ","X"*(1048576-87))
=> true

# And is also true for a 250 byte key.
> Rails.cache.write("X"*250,"X"*(1048576-84-250))
=> true
> Rails.cache.write("X"*250,"X"*(1048576-84-249))
=> false
We should probably be using raw: true in large_object_store, which gives us a little more room; now the overhead appears to be 72 bytes:

> Rails.cache.write("X","X"*(1048576-64),raw:true)
=> false
> Rails.cache.write("X","X"*(1048576-74),raw:true)
=> true
> Rails.cache.write("X","X"*(1048576-72),raw:true)
=> true
> Rails.cache.write("X","X"*(1048576-71),raw:true)
=> false
> Rails.cache.write("X"*250,"X"*(1048576-72-250),raw:true)
=> true
> Rails.cache.write("X"*250,"X"*(1048576-72-249),raw:true)
=> true
> Rails.cache.write("X"*250,"X"*(1048576-72-248),raw:true)
=> false
> 
```

This PR tries to address these problems by subtracting the key length from the slice size used.

This also sets `raw: true` on the serialized slice pages, which should give a little more headroom.

Also: I noticed the calls to `@store.write` did not check return value, so if a write operation failed on the underlying cache store, the `write` method would still return `true`. It will now return `false` if any of the underlying cache writes fail.

Also, changed the order so that the the `#{key}_0` page with the count is stored last so that we only claim the object is present in cache once all of its pages have been written.

@anamartinez @grosser 