### PR TITLE
enforce key order when using read_multi

### DIFF
--- a/lib/large_object_store.rb
+++ b/lib/large_object_store.rb
@@ -63,8 +63,9 @@ module LargeObjectStore
 
       data = if pages.is_a?(Fixnum)
         # read sliced data
-        keys = Array.new(pages).each_with_index.map{|_,i| key(key, i+1) }
-        slices = @store.read_multi(*keys).values
+        keys = (1..pages).map { |i| key(key, i) }
+        # use values_at to enforce key order because read_multi doesn't guarantee a return order
+        slices = @store.read_multi(*keys).values_at(*keys)
         return nil if slices.compact.size != pages
         slices.map! { |s| [s.slice!(0, UUID_SIZE), s] }
         return nil unless slices.map(&:first).uniq == [uuid]

--- a/spec/large_object_store_spec.rb
+++ b/spec/large_object_store_spec.rb
@@ -197,6 +197,16 @@ describe LargeObjectStore do
     store.read("a").size.should == 5_000_000
   end
 
+  it "handles read_multi returning results in any order" do
+    store.write("a", "c"*5_000_000) # don't use 'a' because it is a valid flag option
+    keys = ["a_#{version}_1", "a_#{version}_2", "a_#{version}_3", "a_#{version}_4", "a_#{version}_5"]
+    out_of_order_hash = keys.reverse.each_with_object({}) do |k, h|
+      h[k] = store.store.read(k)
+    end
+    store.store.should_receive(:read_multi).and_return out_of_order_hash
+    store.read("a").size.should == 5_000_000
+  end
+
   describe "#fetch" do
     it "executes the block on miss" do
       store.fetch("a"){ 1 }.should == 1


### PR DESCRIPTION
We can't guarantee the order that `read_multi` will return the keys in, so when we fetch all of our keys, make sure the slices stay in the right order. 

@anamartinez @grosser @ggrossman 