### PR TITLE
Add support for custom serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem "rake"
 gem "rspec", "~>2"
 gem "dalli"
 gem "activesupport", "~> 6.0" # 7 does not support old rubies TODO: setup multiple gemfiles
+gem "oj"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     minitest (5.15.0)
+    oj (3.13.11)
     rake (12.3.0)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
@@ -40,6 +41,7 @@ DEPENDENCIES
   bump
   dalli
   large_object_store!
+  oj
   rake
   rspec (~> 2)
 


### PR DESCRIPTION
This enables alternative serializers such as `Oj` to be plugged in instead of `Marshal`.

The serializer can be any object that implements `dump` and `load` methods.

@grosser @claire-kz
